### PR TITLE
Fix pathfinding spam, simplify options

### DIFF
--- a/MedBot/Main.lua
+++ b/MedBot/Main.lua
@@ -135,17 +135,32 @@ function handleIdleState()
 		return
 	end
 
-	local goalNode = findGoalNode(currentTask)
-	if not goalNode then
-		Log:Warn("Could not find goal node")
-		return
-	end
+        local goalNode, goalPos = findGoalNode(currentTask)
+        if not goalNode then
+                Log:Warn("Could not find goal node")
+                return
+        end
 
-	-- Avoid pathfinding if we're already at the goal
-	if startNode.id == goalNode.id then
-		Log:Debug("Already at goal node %d, staying in IDLE", startNode.id)
-		return
-	end
+        -- Avoid pathfinding if we're already at the goal
+        if startNode.id == goalNode.id then
+                -- Try direct movement or internal path before giving up
+                if goalPos and isWalkable.Path(G.pLocal.Origin, goalPos) then
+                        G.Navigation.path = { { pos = goalPos, id = goalNode.id } }
+                        G.currentState = G.States.MOVING
+                        G.lastPathfindingTick = currentTick
+                else
+                        local internal = Navigation.GetInternalPath(G.pLocal.Origin, goalPos)
+                        if internal then
+                                G.Navigation.path = internal
+                                G.currentState = G.States.MOVING
+                                G.lastPathfindingTick = currentTick
+                        else
+                                Log:Debug("Already at goal node %d, staying in IDLE", startNode.id)
+                                G.lastPathfindingTick = currentTick
+                        end
+                end
+                return
+        end
 
 	Log:Info("Generating new path from node %d to node %d", startNode.id, goalNode.id)
 	WorkManager.addWork(Navigation.FindPath, { startNode, goalNode }, 33, "Pathfinding")
@@ -240,52 +255,57 @@ function findGoalNode(currentTask)
 	local pLocal = G.pLocal.entity
 	local mapName = engine.GetMapName():lower()
 
-	local function findPayloadGoal()
-		G.World.payloads = entities.FindByClass("CObjectCartDispenser")
-		for _, entity in pairs(G.World.payloads) do
-			if entity:GetTeamNumber() == pLocal:GetTeamNumber() then
-				return Navigation.GetClosestNode(entity:GetAbsOrigin())
-			end
-		end
-	end
+        local function findPayloadGoal()
+                G.World.payloads = entities.FindByClass("CObjectCartDispenser")
+                for _, entity in pairs(G.World.payloads) do
+                        if entity:GetTeamNumber() == pLocal:GetTeamNumber() then
+                                local pos = entity:GetAbsOrigin()
+                                return Navigation.GetClosestNode(pos), pos
+                        end
+                end
+        end
 
-	local function findFlagGoal()
-		local myItem = pLocal:GetPropInt("m_hItem")
-		G.World.flags = entities.FindByClass("CCaptureFlag")
-		for _, entity in pairs(G.World.flags) do
-			local myTeam = entity:GetTeamNumber() == pLocal:GetTeamNumber()
-			if (myItem > 0 and myTeam) or (myItem < 0 and not myTeam) then
-				return Navigation.GetClosestNode(entity:GetAbsOrigin())
-			end
-		end
-	end
+        local function findFlagGoal()
+                local myItem = pLocal:GetPropInt("m_hItem")
+                G.World.flags = entities.FindByClass("CCaptureFlag")
+                for _, entity in pairs(G.World.flags) do
+                        local myTeam = entity:GetTeamNumber() == pLocal:GetTeamNumber()
+                        if (myItem > 0 and myTeam) or (myItem < 0 and not myTeam) then
+                                local pos = entity:GetAbsOrigin()
+                                return Navigation.GetClosestNode(pos), pos
+                        end
+                end
+        end
 
-	local function findHealthGoal()
-		local closestDist = math.huge
-		local closestNode = nil
-		for _, pos in pairs(G.World.healthPacks) do
-			local healthNode = Navigation.GetClosestNode(pos)
-			if healthNode then
-				local dist = (G.pLocal.Origin - pos):Length()
-				if dist < closestDist then
-					closestDist = dist
-					closestNode = healthNode
-				end
-			end
-		end
-		return closestNode
-	end
+        local function findHealthGoal()
+                local closestDist = math.huge
+                local closestNode = nil
+                local closestPos = nil
+                for _, pos in pairs(G.World.healthPacks) do
+                        local healthNode = Navigation.GetClosestNode(pos)
+                        if healthNode then
+                                local dist = (G.pLocal.Origin - pos):Length()
+                                if dist < closestDist then
+                                        closestDist = dist
+                                        closestNode = healthNode
+                                        closestPos = pos
+                                end
+                        end
+                end
+                return closestNode, closestPos
+        end
 
 	-- Find and follow the closest teammate using FastPlayers
-	local function findFollowGoal()
-		local localWP = Common.FastPlayers.GetLocal()
-		if not localWP then
-			return nil
-		end
-		local origin = localWP:GetRawEntity():GetAbsOrigin()
-		local closestDist = math.huge
-		local closestNode = nil
-		local foundTarget = false
+        local function findFollowGoal()
+                local localWP = Common.FastPlayers.GetLocal()
+                if not localWP then
+                        return nil
+                end
+                local origin = localWP:GetRawEntity():GetAbsOrigin()
+                local closestDist = math.huge
+                local closestNode = nil
+                local targetPos = nil
+                local foundTarget = false
 
 		for _, wp in ipairs(Common.FastPlayers.GetTeammates(true)) do
 			local ent = wp:GetRawEntity()
@@ -293,20 +313,22 @@ function findGoalNode(currentTask)
 				foundTarget = true
 				local pos = ent:GetAbsOrigin()
 				local dist = (pos - origin):Length()
-				if dist < closestDist then
-					closestDist = dist
-					-- Update our memory of where we last saw this target
-					G.Navigation.lastKnownTargetPosition = pos
-					closestNode = Navigation.GetClosestNode(pos)
-				end
-			end
-		end
+                                if dist < closestDist then
+                                        closestDist = dist
+                                        -- Update our memory of where we last saw this target
+                                        G.Navigation.lastKnownTargetPosition = pos
+                                        closestNode = Navigation.GetClosestNode(pos)
+                                        targetPos = pos
+                                end
+                        end
+                end
 
 		-- If no alive teammates found, but we have a last known position, use that
 		if not foundTarget and G.Navigation.lastKnownTargetPosition then
 			Log:Info("No alive teammates found, moving to last known position")
-			closestNode = Navigation.GetClosestNode(G.Navigation.lastKnownTargetPosition)
-		end
+                        closestNode = Navigation.GetClosestNode(G.Navigation.lastKnownTargetPosition)
+                        targetPos = G.Navigation.lastKnownTargetPosition
+                end
 
 		-- If the target is very close (same node), add some distance to avoid pathfinding to self
 		if closestNode and closestDist < 150 then -- 150 units is quite close
@@ -327,26 +349,26 @@ function findGoalNode(currentTask)
 			end
 		end
 
-		return closestNode
-	end
+                return closestNode, targetPos
+        end
 
 	if currentTask == "Objective" then
 		if mapName:find("plr_") or mapName:find("pl_") then
-			return findPayloadGoal()
-		elseif mapName:find("ctf_") then
-			return findFlagGoal()
-		else
-			-- fallback to following the closest teammate
-			return findFollowGoal()
-		end
-	elseif currentTask == "Health" then
-		return findHealthGoal()
-	elseif currentTask == "Follow" then
-		return findFollowGoal()
-	else
-		Log:Debug("Unknown task: %s", currentTask)
-	end
-	return nil
+                        return findPayloadGoal()
+                elseif mapName:find("ctf_") then
+                        return findFlagGoal()
+                else
+                        -- fallback to following the closest teammate
+                        return findFollowGoal()
+                end
+        elseif currentTask == "Health" then
+                return findHealthGoal()
+        elseif currentTask == "Follow" then
+                return findFollowGoal()
+        else
+                Log:Debug("Unknown task: %s", currentTask)
+        end
+        return nil
 end
 
 -- Function to move towards the current node (simplified for better FPS)
@@ -412,10 +434,9 @@ function moveTowardsNode(userCmd, node)
 
 		G.Navigation.currentNodeTicks = G.Navigation.currentNodeTicks + 1
 
-		-- Expensive walkability verification - only when stuck for a while
-		if G.Navigation.currentNodeTicks > 66 then
-			local cooldownTicks = G.Menu.Main.OptimizerCooldown or 12
-			if not isWalkable.Path(LocalOrigin, node.pos) then
+                -- Expensive walkability verification - only when stuck for a while
+                if G.Navigation.currentNodeTicks > 66 then
+                        if not isWalkable.Path(LocalOrigin, node.pos) then
 				Log:Warn("Path to current node blocked after being stuck, repathing...")
 				-- Add failure penalty to current connection if we have one
 				local path = G.Navigation.path
@@ -572,10 +593,9 @@ Commands.Register("pf_hierarchical", function(args)
 			"Will process across multiple ticks to prevent freezing",
 			5
 		)
-	elseif args[1] == "status" then
-		-- Check setup progress by accessing the SetupState (we need to expose this)
-		local G = require("MedBot.Utils.Globals")
-		if G.Navigation.hierarchical then
+        elseif args[1] == "status" then
+                -- Check setup progress by accessing the SetupState
+                if G.Navigation.hierarchical then
 			print("Hierarchical network ready and available")
 		else
 			print("Hierarchical network not yet available - check if setup is in progress")
@@ -807,45 +827,6 @@ Commands.Register("pf_costs", function(args)
 	end
 end)
 
-Commands.Register("pf_optimizer", function(args)
-	if args[1] == "info" then
-		print("Path Optimiser Settings:")
-		print(string.format("  Lookahead Nodes: %d", G.Menu.Main.OptimizerLookahead or 10))
-		print(string.format("  Lookahead Distance: %d units", G.Menu.Main.OptimizerDistance or 600))
-		print(string.format("  Failure Cooldown: %d ticks", G.Menu.Main.OptimizerCooldown or 12))
-
-		local cacheSize = 0
-		for _ in pairs(Optimiser.cache) do
-			cacheSize = cacheSize + 1
-		end
-		print(string.format("  Cached failures: %d", cacheSize))
-	elseif args[1] == "clear" then
-		Optimiser.cache = {}
-		print("Optimiser failure cache cleared")
-	elseif args[1] == "test" then
-		local path = G.Navigation.path
-		if path and #path > 1 then
-			local origin = G.pLocal.Origin
-			local startTime = os.clock()
-			local targetIdx = Optimiser:getBestTarget(origin, path, 1)
-			local endTime = os.clock()
-			local timeTaken = (endTime - startTime) * 1000 -- Convert to milliseconds
-
-			print(string.format("Optimiser test results:"))
-			print(string.format("  Path length: %d nodes", #path))
-			print(string.format("  Best target: node %d", targetIdx))
-			print(string.format("  Skip count: %d nodes", targetIdx - 1))
-			print(string.format("  Time taken: %.3f ms", timeTaken))
-		else
-			print("No active path to test")
-		end
-	else
-		print("Usage: pf_optimizer info | clear | test")
-		print("  info  - Show optimiser settings and cache status")
-		print("  clear - Clear failure cache")
-		print("  test  - Test optimiser performance on current path")
-	end
-end)
 
 Notify.Alert("MedBot loaded!")
 if entities.GetLocalPlayer() then

--- a/MedBot/Menu.lua
+++ b/MedBot/Menu.lua
@@ -13,6 +13,7 @@ local MenuModule = {}
 
 -- Import globals
 local G = require("MedBot.Utils.Globals")
+local Node = require("MedBot.Modules.Node")
 
 -- Try loading TimMenu
 ---@type boolean, table
@@ -64,9 +65,9 @@ local function OnDrawMenu()
 			TimMenu.Tooltip("Enable intelligent jumping over obstacles (works even when MedBot is disabled)")
 			TimMenu.NextLine()
 
-			-- Walkable Mode Selector for both node skipping and SmartJump
-			G.Menu.Main.WalkableMode = G.Menu.Main.WalkableMode or "Smooth"
-			local walkableModes = { "Smooth Walking (Step 18u)", "Aggressive Walking (Jump 72u)" }
+                        -- Path optimisation mode for following nodes
+                        G.Menu.Main.WalkableMode = G.Menu.Main.WalkableMode or "Smooth"
+                        local walkableModes = { "Smooth (18u steps)", "Aggressive (72u jumps)" }
 			-- Get current mode as index number
 			local currentModeIndex = (G.Menu.Main.WalkableMode == "Aggressive") and 2 or 1
 			local previousMode = G.Menu.Main.WalkableMode
@@ -82,36 +83,14 @@ local function OnDrawMenu()
 			end
 
 			-- Auto-recalculate costs if mode changed
-			if G.Menu.Main.WalkableMode ~= previousMode then
-				local success, Node = pcall(require, "MedBot.Modules.Node")
-				if success and Node then
-					Node.RecalculateConnectionCosts()
-				end
-			end
-			TimMenu.Tooltip("Smooth: Only 18-unit steps + height costs, Aggressive: Allow 72-unit jumps no extra cost")
-			TimMenu.EndSector()
+                        if G.Menu.Main.WalkableMode ~= previousMode then
+                                Node.RecalculateConnectionCosts()
+                        end
+                        TimMenu.Tooltip("Applies to path following only. Aggressive also enables direct skipping when path is walkable")
+                        TimMenu.EndSector()
 
-			TimMenu.NextLine()
 
-			-- Path Optimiser Settings
-			TimMenu.BeginSector("Path Optimiser (Advanced)")
-			G.Menu.Main.OptimizerLookahead = G.Menu.Main.OptimizerLookahead or 10
-			G.Menu.Main.OptimizerLookahead = TimMenu.Slider("Lookahead Nodes", G.Menu.Main.OptimizerLookahead, 5, 30, 1)
-			TimMenu.Tooltip("How many nodes ahead to check for skipping (higher = more aggressive skipping)")
-			TimMenu.NextLine()
-
-			G.Menu.Main.OptimizerDistance = G.Menu.Main.OptimizerDistance or 600
-			G.Menu.Main.OptimizerDistance =
-				TimMenu.Slider("Lookahead Distance", G.Menu.Main.OptimizerDistance, 300, 1200, 50)
-			TimMenu.Tooltip("Maximum distance in units to check for skipping")
-			TimMenu.NextLine()
-
-			G.Menu.Main.OptimizerCooldown = G.Menu.Main.OptimizerCooldown or 12
-			G.Menu.Main.OptimizerCooldown = TimMenu.Slider("Failure Cooldown", G.Menu.Main.OptimizerCooldown, 6, 60, 3)
-			TimMenu.Tooltip("How many ticks to wait before retrying a failed skip (prevents oscillation)")
-			TimMenu.EndSector()
-
-			TimMenu.NextLine()
+                        TimMenu.NextLine()
 
 			-- Advanced Settings Section
 			TimMenu.BeginSector("Advanced Settings")
@@ -131,9 +110,8 @@ local function OnDrawMenu()
 			TimMenu.NextLine()
 
 			-- Connection processing status display
-			if G.Menu.Main.CleanupConnections then
-				local Node = require("MedBot.Modules.Node")
-				local status = Node.GetConnectionProcessingStatus()
+                        if G.Menu.Main.CleanupConnections then
+                                local status = Node.GetConnectionProcessingStatus()
 				if status.isProcessing then
 					local phaseNames = {
 						[1] = "Basic validation",

--- a/MedBot/Navigation.lua
+++ b/MedBot/Navigation.lua
@@ -132,9 +132,8 @@ function Navigation.AddCostToConnection(nodeA, nodeB, cost)
 		return
 	end
 
-	-- Use Node module's implementation to avoid duplication
-	local Node = require("MedBot.Modules.Node")
-	Node.AddCostToConnection(nodeA, nodeB, cost)
+        -- Use Node module's implementation to avoid duplication
+        Node.AddCostToConnection(nodeA, nodeB, cost)
 end
 
 --[[
@@ -572,9 +571,7 @@ function Navigation.GetInternalPath(startPos, endPos, maxDistance)
 		end
 
 		-- If both positions are in the same area, use fine points for internal navigation
-		if startArea and endArea and startArea.id == endArea.id then
-			local Node = require("MedBot.Modules.Node")
-			local AStar = require("MedBot.Utils.A-Star")
+                if startArea and endArea and startArea.id == endArea.id then
 
 			-- Find closest fine points to start and end
 			local startPoint = Node.GetClosestAreaPoint(startArea.id, startPos)

--- a/MedBot/Utils/DefaultConfig.lua
+++ b/MedBot/Utils/DefaultConfig.lua
@@ -15,7 +15,7 @@ defaultconfig = {
 		SelfHealTreshold = 45, -- Health percentage to start looking for healthPacks
 		smoothFactor = 0.05,
 		LookingAhead = false, -- Enable automatic camera rotation towards target node
-		WalkableMode = "Step", -- "Step" for 18-unit steps only, "Jump" for 72-unit duck jumps
+                WalkableMode = "Smooth", -- "Smooth" uses 18-unit steps, "Aggressive" allows 72-unit jumps
 		CleanupConnections = false, -- Cleanup invalid connections during map load (disable to prevent crashes)
 		AllowExpensiveChecks = true, -- Allow expensive walkability checks for proper stair/ramp connections
 		-- Hierarchical pathfinding settings (fixed 24-unit spacing)

--- a/MedBot/Visuals.lua
+++ b/MedBot/Visuals.lua
@@ -1,6 +1,7 @@
 --[[ Imports ]]
 local Common = require("MedBot.Common")
 local G = require("MedBot.Utils.Globals")
+local Node = require("MedBot.Modules.Node")
 
 local Visuals = {}
 
@@ -271,12 +272,10 @@ local function OnDraw()
 	end
 
 	-- Draw fine-grained points within areas (hierarchical pathfinding)
-	if G.Menu.Visuals.showFinePoints and G.Menu.Main.UseHierarchicalPathfinding then
-		local Node = require("MedBot.Modules.Node")
-
-		-- Track drawn inter-area connections to avoid duplicates
-		local drawnInterConnections = {}
-		local drawnIntraConnections = {}
+        if G.Menu.Visuals.showFinePoints and G.Menu.Main.UseHierarchicalPathfinding then
+                -- Track drawn inter-area connections to avoid duplicates
+                local drawnInterConnections = {}
+                local drawnIntraConnections = {}
 
 		for id, entry in pairs(visibleNodes) do
 			local points = Node.GetAreaPoints(id)


### PR DESCRIPTION
## Summary
- refactor Walkable Mode selector and drop unused optimiser settings
- default to smooth walking mode
- avoid pathfinding spam and walk directly when goal node is the same
- remove old optimiser command

## Testing
- `node bundle.js`

------
https://chatgpt.com/codex/tasks/task_e_6877eebc0ec8832c801456b5ef5ff2a6