### PR TITLE
Add SmartJump debug toggle

### DIFF
--- a/MedBot/Menu.lua
+++ b/MedBot/Menu.lua
@@ -61,9 +61,14 @@ local function OnDrawMenu()
 
 			-- Smart Jump (works independently of MedBot enable state)
 			G.Menu.SmartJump = G.Menu.SmartJump or {}
-			G.Menu.SmartJump.Enable = TimMenu.Checkbox("Smart Jump", G.Menu.SmartJump.Enable ~= false)
-			TimMenu.Tooltip("Enable intelligent jumping over obstacles (works even when MedBot is disabled)")
-			TimMenu.NextLine()
+                        G.Menu.SmartJump.Enable = TimMenu.Checkbox("Smart Jump", G.Menu.SmartJump.Enable ~= false)
+                        TimMenu.Tooltip("Enable intelligent jumping over obstacles (works even when MedBot is disabled)")
+                        TimMenu.NextLine()
+
+                        G.Menu.SmartJump.Debug = G.Menu.SmartJump.Debug or false
+                        G.Menu.SmartJump.Debug = TimMenu.Checkbox("Smart Jump Debug", G.Menu.SmartJump.Debug)
+                        TimMenu.Tooltip("Print Smart Jump debug logs to console")
+                        TimMenu.NextLine()
 
                         -- Path optimisation mode for following nodes
                         G.Menu.Main.WalkableMode = G.Menu.Main.WalkableMode or "Smooth"

--- a/MedBot/Utils/DefaultConfig.lua
+++ b/MedBot/Utils/DefaultConfig.lua
@@ -43,11 +43,15 @@ defaultconfig = {
 		showInterConnections = true, -- Show connections between different areas (orange)
 		showEdgeConnections = true, -- Show edge-to-edge connections within areas (bright blue)
 	},
-	Movement = {
-		lookatpath = false, -- Look at where we are walking
-		smoothLookAtPath = true, -- Set this to true to enable smooth look at path
-		Smart_Jump = true, -- jumps perfectly before obstacle to be at peek of jump height when at colision point
-	},
+        Movement = {
+                lookatpath = false, -- Look at where we are walking
+                smoothLookAtPath = true, -- Set this to true to enable smooth look at path
+                Smart_Jump = true, -- jumps perfectly before obstacle to be at peek of jump height when at colision point
+        },
+        SmartJump = {
+                Enable = true,
+                Debug = false,
+        },
 }
 
 return defaultconfig


### PR DESCRIPTION
## Summary
- add SmartJump debug toggle in menu and config
- respect the toggle in SmartJump module by wrapping debug logs

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6878079e6890832c95b346a747d9a73f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Smart Jump Debug" option in the menu, allowing users to toggle debug log printing for the Smart Jump feature.
  * Introduced a dedicated configuration section for Smart Jump settings, including enable and debug options.

* **Improvements**
  * Debug logs for Smart Jump are now only shown when the debug option is enabled, giving users more control over logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->