### PR TITLE
Improve fine node penalty handling

### DIFF
--- a/MedBot/Main.lua
+++ b/MedBot/Main.lua
@@ -709,9 +709,29 @@ function handleStuckState(userCmd)
 	local shouldForceRepath = false
 	local connectionBlocked = false
 
-	if path and #path > 1 then
-		local currentNode = path[1]
-		local nextNode = path[2]
+                if path and #path > 1 then
+                        local currentNode, nextNode
+
+                        -- Determine which path segment we are closest to
+                        local closestIndex, closestDist = 1, math.huge
+                        local pPos = G.pLocal.Origin
+                        for i = 1, #path do
+                                local node = path[i]
+                                local dist = (node.pos - pPos):Length()
+                                if dist < closestDist then
+                                        closestDist = dist
+                                        closestIndex = i
+                                end
+                        end
+
+                        if closestIndex >= #path then
+                                closestIndex = #path - 1
+                        end
+
+                        if closestIndex >= 1 then
+                                currentNode = path[closestIndex]
+                                nextNode = path[closestIndex + 1]
+                        end
 
 		if currentNode and nextNode and currentNode.id and nextNode.id and currentNode.id ~= nextNode.id then
 			-- Check if this connection is blocked by circuit breaker
@@ -735,9 +755,28 @@ function handleStuckState(userCmd)
 		end
 
 		ProfilerBegin("stuck_penalty_analysis")
-		if path and #path > 1 then
-			local currentNode = path[1]
-			local nextNode = path[2]
+                if path and #path > 1 then
+                        local currentNode, nextNode
+                        -- Reuse closest segment logic to target the problematic edge
+                        local closestIndex, closestDist = 1, math.huge
+                        local pPos = G.pLocal.Origin
+                        for i = 1, #path do
+                                local node = path[i]
+                                local dist = (node.pos - pPos):Length()
+                                if dist < closestDist then
+                                        closestDist = dist
+                                        closestIndex = i
+                                end
+                        end
+
+                        if closestIndex >= #path then
+                                closestIndex = #path - 1
+                        end
+
+                        if closestIndex >= 1 then
+                                currentNode = path[closestIndex]
+                                nextNode = path[closestIndex + 1]
+                        end
 			-- Better validation to prevent invalid penalties
 			if currentNode and nextNode and currentNode.id and nextNode.id and currentNode.id ~= nextNode.id then
 				-- Only do expensive walkability check if not already blocked by circuit breaker

--- a/MedBot/Modules/Node.lua
+++ b/MedBot/Modules/Node.lua
@@ -1699,35 +1699,101 @@ end
 ---@param nodeB table Second node (destination)
 function Node.AddFailurePenalty(nodeA, nodeB, penalty)
         penalty = penalty or 100
-	if not nodeA or not nodeB then
-		return
-	end
-	local nodes = G.Navigation.nodes
-	if not nodes then
-		return
-	end
+        if not nodeA or not nodeB then
+                return
+        end
 
-        -- Helper to apply penalty in one direction
-        local function applyPenalty(fromNode, toNode)
-                for _, cDir in pairs(nodes[fromNode.id] and nodes[fromNode.id].c or {}) do
+        local nodes = G.Navigation.nodes
+        if not nodes then
+                return
+        end
+
+        -- Resolve area IDs for both nodes (supports fine points)
+        -- Prefer parentArea when present to avoid mixing fine point IDs with area IDs
+        local function resolveAreaId(n)
+                if not n then
+                        return nil
+                end
+
+                if n.parentArea then
+                        return n.parentArea
+                end
+
+                return n.id
+        end
+
+        -- Helper to apply penalty in one direction for area connections
+        local function applyAreaPenalty(fromAreaId, toAreaId)
+                if not (fromAreaId and toAreaId) then
+                        return false
+                end
+                for _, cDir in pairs(nodes[fromAreaId] and nodes[fromAreaId].c or {}) do
                         if cDir and cDir.connections then
                                 for i, connection in pairs(cDir.connections) do
                                         local targetNodeId = getConnectionNodeId(connection)
-                                        if targetNodeId == toNode.id then
+                                        if targetNodeId == toAreaId then
                                                 local currentCost = getConnectionCost(connection)
                                                 local newCost = currentCost + penalty
                                                 cDir.connections[i] = { node = targetNodeId, cost = newCost }
                                                 Log:Debug(
                                                         "Added failure penalty to connection %d -> %d: %.1f -> %.1f",
-                                                        fromNode.id,
-                                                        toNode.id,
+                                                        fromAreaId,
+                                                        toAreaId,
                                                         currentCost,
                                                         newCost
                                                 )
-                                                return
+                                                return true
                                         end
                                 end
                         end
+                end
+                return false
+        end
+
+        -- Helper to apply penalty for fine point neighbors
+        local function applyFinePenalty(fromNode, toNode)
+                if not fromNode.neighbors then
+                        return false
+                end
+                for _, neighbor in ipairs(fromNode.neighbors) do
+                        if neighbor.point
+                                and (neighbor.point == toNode
+                                        or (neighbor.point.id == toNode.id
+                                                and neighbor.point.parentArea == toNode.parentArea)) then
+                                local currentCost = neighbor.cost or 1
+                                local newCost = currentCost + penalty
+                                neighbor.cost = newCost
+                                Log:Debug(
+                                        "Added fine failure penalty to point %d (area %s) -> %d (area %s): %.1f -> %.1f",
+                                        fromNode.id or -1,
+                                        fromNode.parentArea or "?",
+                                        toNode.id or -1,
+                                        toNode.parentArea or "?",
+                                        currentCost,
+                                        newCost
+                                )
+                                return true
+                        end
+                end
+                return false
+        end
+
+        local function applyPenalty(fromNode, toNode)
+                -- First try area-level penalty
+                local fromArea = resolveAreaId(fromNode)
+                local toArea = resolveAreaId(toNode)
+                local appliedArea = applyAreaPenalty(fromArea, toArea)
+
+                -- Then fine-point penalty if applicable
+                local appliedFine = applyFinePenalty(fromNode, toNode)
+
+                -- Debug if no connection was updated
+                if not appliedArea and not appliedFine then
+                        Log:Warn(
+                                "Skipping penalty for invalid connection: %s->%s",
+                                tostring(fromArea or fromNode.id),
+                                tostring(toArea or toNode.id)
+                        )
                 end
         end
 


### PR DESCRIPTION
## Summary
- refine `applyFinePenalty` checks to ensure neighbor entries have `point`
- keep penalties accumulating for bidirectional fine connections

## Testing
- `npm -s test`

------
https://chatgpt.com/codex/tasks/task_e_68782f77ddc0832c98d8f7386073081b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the bot identifies the closest segment of its navigation path when stuck, resulting in more accurate stuck state detection and handling.

* **Refactor**
  * Enhanced the logic for applying penalties to navigation connections, allowing for more precise adjustments at both area and fine point levels, and improved error logging for invalid connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->