### PR TITLE
Add grid-based nav-mesh rendering

### DIFF
--- a/FAST_NAV_DRAWING.md
+++ b/FAST_NAV_DRAWING.md
@@ -1,0 +1,42 @@
+# Fast Nav Mesh Drawing
+
+Below is a quick reference for implementing lightweight nav-mesh visualization with chunked lookup.
+
+| Step | Action | Purpose |
+| ---- | ------ | ------- |
+| **1.** | **Build `gridIndex` after `Navigation.Setup()`** using `buildGrid()` which buckets each node by `[cx][cy][cz]` where `c* = floor(pos / chunkSize)`. | Prepare a lookup table before drawing. |
+| **2.** | **Store only node IDs** – `nodeCell[id] = {cx,cy,cz}`. | Avoid allocations during drawing. |
+| **3.** | Expose two sliders in the menu: `chunkSize` (64‑512 uu) and `renderChunks` (Manhattan radius 1‑10). | User controls precision and range. |
+| **4.** | **Per-frame** `collectVisible(me)`<br>· calculate your cell `(px,py,pz)`<br>· iterate a diamond radius of `renderChunks`<br>· copy ids from each bucket into reusable `visBuf`. | Touch only needed areas; no allocations. |
+| **5.** | **Draw** using `visBuf` (`for i=1,visCount do …`). Retrieve fine points with `Node.GetAreaPoints(id)` only here. | Nothing outside the radius hits the GPU or GC. |
+| **6.** | **Rebuild** the grid when the map or sliders (`chunkSize`/`renderChunks`) change. | Keeps the table consistent with settings. |
+
+```lua
+-- loader.lua
+Navigation.Setup()
+require("MedBot.Visuals").Initialize()   -- grid builds only once
+
+-- Visuals.lua (extract)
+local function collectVisible(me)
+  visCount = 0
+  local px,py,pz = worldToCell(me:GetAbsOrigin())
+  local r = cfg.renderChunks
+  for dx=-r,r do
+    local ax = math.abs(dx)
+    for dy=-(r-ax),(r-ax) do
+      local dzMax = r-ax-math.abs(dy)
+      for dz=-dzMax,dzMax do
+        local b = gridIndex[px+dx] and gridIndex[px+dx][py+dy] and gridIndex[px+dx][py+dy][pz+dz]
+        if b then
+          for _,id in ipairs(b) do
+            visCount=visCount+1
+            visBuf[visCount]=id
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+This approach inspects only about \~$2 r^3$ buckets instead of all nodes, avoids short-lived tables, and allows the menu to expand or shrink the range on the fly.

--- a/MedBot/Menu.lua
+++ b/MedBot/Menu.lua
@@ -14,6 +14,7 @@ local MenuModule = {}
 -- Import globals
 local G = require("MedBot.Utils.Globals")
 local Node = require("MedBot.Modules.Node")
+local Visuals = require("MedBot.Visuals")
 
 -- Try loading TimMenu
 ---@type boolean, table
@@ -159,10 +160,21 @@ local function OnDrawMenu()
 			G.Menu.Visuals.EnableVisuals = TimMenu.Checkbox("Enable Visuals", G.Menu.Visuals.EnableVisuals)
 			TimMenu.NextLine()
 
-			G.Menu.Visuals.renderDistance = G.Menu.Visuals.renderDistance or 800
-			G.Menu.Visuals.renderDistance =
-				TimMenu.Slider("Render Distance", G.Menu.Visuals.renderDistance, 100, 3000, 100)
-			TimMenu.EndSector()
+                        G.Menu.Visuals.renderDistance = G.Menu.Visuals.renderDistance or 800
+                        G.Menu.Visuals.renderDistance =
+                                TimMenu.Slider("Render Distance", G.Menu.Visuals.renderDistance, 100, 3000, 100)
+                        TimMenu.NextLine()
+
+                        G.Menu.Visuals.chunkSize = G.Menu.Visuals.chunkSize or 256
+                        G.Menu.Visuals.chunkSize =
+                                TimMenu.Slider("Chunk Size", G.Menu.Visuals.chunkSize, 64, 512, 16)
+                        TimMenu.NextLine()
+
+                        G.Menu.Visuals.renderChunks = G.Menu.Visuals.renderChunks or 3
+                        G.Menu.Visuals.renderChunks =
+                                TimMenu.Slider("Render Chunks", G.Menu.Visuals.renderChunks, 1, 10, 1)
+                        Visuals.MaybeRebuildGrid()
+                        TimMenu.EndSector()
 
 			TimMenu.NextLine()
 

--- a/MedBot/Navigation.lua
+++ b/MedBot/Navigation.lua
@@ -17,6 +17,7 @@ local Navigation = {}
 local Common = require("MedBot.Common")
 local G = require("MedBot.Utils.Globals")
 local Node = require("MedBot.Modules.Node")
+local Visuals = require("MedBot.Visuals")
 local AStar = require("MedBot.Utils.A-Star")
 local Lib = Common.Lib
 local Log = Lib.Utils.Logger.new("MedBot")
@@ -253,10 +254,13 @@ end
 ]]
 
 function Navigation.Setup()
-	if engine.GetMapName() then
-		Node.Setup()
-		Navigation.ClearPath()
-	end
+        if engine.GetMapName() then
+                Node.Setup()
+                if Visuals and Visuals.BuildGrid then
+                        Visuals.BuildGrid()
+                end
+                Navigation.ClearPath()
+        end
 end
 
 -- Get the current path

--- a/MedBot/Utils/DefaultConfig.lua
+++ b/MedBot/Utils/DefaultConfig.lua
@@ -21,9 +21,11 @@ defaultconfig = {
 		-- Hierarchical pathfinding settings (fixed 24-unit spacing)
 		UseHierarchicalPathfinding = false, -- Enable fine-grained points within areas for better accuracy
 	},
-	Visuals = {
-		renderDistance = 400,
-		EnableVisuals = true,
+        Visuals = {
+                renderDistance = 400,
+                chunkSize = 256,
+                renderChunks = 3,
+                EnableVisuals = true,
 		memoryUsage = true,
 		-- Combo-based display options
 		basicDisplay = { true, true, true, true, false }, -- Show Nodes, Node IDs, Nav Connections, Areas, Fine Points

--- a/MedBot/Visuals.lua
+++ b/MedBot/Visuals.lua
@@ -10,6 +10,14 @@ local Notify = Lib.UI.Notify
 local Fonts = Lib.UI.Fonts
 local tahoma_bold = draw.CreateFont("Tahoma", 12, 800, FONTFLAG_OUTLINE)
 
+-- Grid-based rendering helpers
+local gridIndex = {}
+local nodeCell = {}
+local visBuf = {}
+local visCount = 0
+Visuals.lastChunkSize = nil
+Visuals.lastRenderChunks = nil
+
 --[[ Functions ]]
 local function Draw3DBox(size, pos)
 	local halfSize = size / 2
@@ -131,8 +139,71 @@ end
 local AREA_FILL_COLOR = { 55, 255, 155, 12 } -- r, g, b, a for filled area
 local AREA_OUTLINE_COLOR = { 255, 255, 255, 77 } -- r, g, b, a for area outline
 
--- maximum distance to render visuals (in world units)
-local RENDER_DISTANCE = 800 -- fallback default; overridden by G.Menu.Visuals.renderDistance
+-- Convert world position to chunk cell
+local function worldToCell(pos)
+    local size = G.Menu.Visuals.chunkSize or 256
+    return math.floor(pos.x / size), math.floor(pos.y / size), math.floor(pos.z / size)
+end
+
+-- Build lookup grid of node ids per cell
+local function buildGrid()
+    gridIndex = {}
+    nodeCell = {}
+    local size = G.Menu.Visuals.chunkSize or 256
+    for id, node in pairs(G.Navigation.nodes or {}) do
+        local cx, cy, cz = worldToCell(node.pos)
+        gridIndex[cx] = gridIndex[cx] or {}
+        gridIndex[cx][cy] = gridIndex[cx][cy] or {}
+        gridIndex[cx][cy][cz] = gridIndex[cx][cy][cz] or {}
+        table.insert(gridIndex[cx][cy][cz], id)
+        nodeCell[id] = { cx, cy, cz }
+    end
+    Visuals.lastChunkSize = size
+    Visuals.lastRenderChunks = G.Menu.Visuals.renderChunks or 3
+end
+
+-- Rebuild grid if configuration changed
+function Visuals.MaybeRebuildGrid()
+    local size = G.Menu.Visuals.chunkSize or 256
+    local chunks = G.Menu.Visuals.renderChunks or 3
+    if size ~= Visuals.lastChunkSize or chunks ~= Visuals.lastRenderChunks then
+        buildGrid()
+    end
+end
+
+-- External access to rebuild grid
+function Visuals.BuildGrid()
+    buildGrid()
+end
+
+function Visuals.Initialize()
+    buildGrid()
+end
+
+-- Collect visible node ids around player
+local function collectVisible(me)
+    visCount = 0
+    local px, py, pz = worldToCell(me:GetAbsOrigin())
+    local r = G.Menu.Visuals.renderChunks or 3
+    for dx = -r, r do
+        local ax = math.abs(dx)
+        for dy = -(r - ax), (r - ax) do
+            local dzMax = r - ax - math.abs(dy)
+            for dz = -dzMax, dzMax do
+                local bx = gridIndex[px + dx]
+                local by = bx and bx[py + dy]
+                local bucket = by and by[pz + dz]
+                if bucket then
+                    for _, id in ipairs(bucket) do
+                        visCount = visCount + 1
+                        visBuf[visCount] = id
+                    end
+                end
+            end
+        end
+    end
+end
+
 
 local function OnDraw()
 	draw.SetFont(Fonts.Verdana)
@@ -147,8 +218,7 @@ local function OnDraw()
 		return
 	end
 
-	local myPos = me:GetAbsOrigin()
-	local currentY = 120
+        local currentY = 120
 	-- Draw memory usage if enabled in config
 	if G.Menu.Visuals.memoryUsage then
 		draw.SetFont(Fonts.Verdana) -- Ensure font is set before drawing text
@@ -157,19 +227,20 @@ local function OnDraw()
 		draw.Text(10, 10, string.format("Memory Usage: %.1f MB", memMB))
 		currentY = currentY + 20
 	end
-	-- Precompute screen-visible nodes within render distance
-	local visibleNodes = {}
-	-- use menu-configured distance if present
-	local maxDist = G.Menu.Visuals.renderDistance or RENDER_DISTANCE
-	for id, node in pairs(G.Navigation.nodes or {}) do
-		local dist = (myPos - node.pos):Length()
-		if dist <= maxDist then
-			local scr = client.WorldToScreen(node.pos)
-			if scr then
-				visibleNodes[id] = { node = node, screen = scr }
-			end
-		end
-	end
+        -- Collect visible nodes using chunk grid
+        Visuals.MaybeRebuildGrid()
+        collectVisible(me)
+        local visibleNodes = {}
+        for i = 1, visCount do
+                local id = visBuf[i]
+                local node = G.Navigation.nodes and G.Navigation.nodes[id]
+                if node then
+                        local scr = client.WorldToScreen(node.pos)
+                        if scr then
+                                visibleNodes[id] = { node = node, screen = scr }
+                        end
+                end
+        end
 	G.Navigation.currentNodeIndex = G.Navigation.currentNodeIndex or 1 -- Initialize currentNodeIndex if it's nil.
 	if G.Navigation.currentNodeIndex == nil then
 		return

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Support: https://dsc.gg/rosnehook
 
 Credits for original code: Inx00
 
+For an overview of the lightweight nav-mesh rendering method, see
+[FAST_NAV_DRAWING.md](FAST_NAV_DRAWING.md).
+
 # How to use
 
 First, go to https://nodejs.org/ and download and install the stable version of Node.JS


### PR DESCRIPTION
## Summary
- document fast nav drawing approach
- allow configuring chunkSize and renderChunks
- implement grid-based lookup in Visuals
- rebuild drawing grid when map or settings change
- expose new settings in the menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687aad013ce4832c83f7b7cedf7ad758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an optimized navigation node rendering system using a grid-based spatial index for improved performance.
  * Added user-configurable sliders for chunk size and render radius in the Visuals menu, enabling dynamic adjustment of visualization detail.
* **Documentation**
  * Added a new guide detailing the efficient navigation mesh visualization approach.
  * Updated the README to reference the new documentation.
* **Chores**
  * Expanded default configuration with new parameters for chunk size and render radius.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->